### PR TITLE
fix username lenght on azuredb

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -48,7 +48,7 @@
 
 - name: create a user with access only to the icingaweb2 database using the root user
   mysql_user:
-    name: '{{ icinga2_web_icingaweb2_database_user }}'
+    name: '{{ icinga2_web_icingaweb2_database_user.split("@")[0] }}'
     password: '{{ icinga2_web_icingaweb2_database_pass }}'
     priv: '{{ icinga2_web_icingaweb2_database_name }}.*:ALL'
     login_host: '{{ icinga2_web_icingaweb2_database_host }}'


### PR DESCRIPTION
Under some circumstances, the user name on azure can get too long. This extracts the user part from the user name. the domain part is not necessary for creating the user

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
