### PR TITLE
Install icinga director module if corresponding vars are set

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,17 @@ icinga2_web_api_user: icingaweb2
 # icinga2 API password
 icinga2_web_api_pass: 'passw0rd'
 
+# icinga2 director API host
+icinga2_web_director_api_host: 127.0.0.1
+
+# icinga2 director API port
+icinga2_web_director_api_port: 5665
+
+# icinga2 director API user
+icinga2_web_director_api_user: director
+
+# icinga2 director API password
+icinga2_web_director_api_pass: 'passw0rd'
 
 ## icingaweb2 database settings
 # The icingaweb2 database name
@@ -73,7 +84,16 @@ icinga2_web_icinga2_database_ssl: 0
 icinga2_web_icinga2_database_ssl_ca: /etc/pki/tls/certs/ca-bundle.crt
 
 icinga2_web_modules: []
- #- graphite
+ #- name: graphite
+ #  version: master
+ #- name: ipl
+ #  version: v0.5.0
+ #- name: incubator
+ #  version: v0.5.0
+ #- name: reactbundle
+ #  version: v0.7.0
+ #- name: director
+ #  version: v1.7.2
 
 # Icingaweb2 LDAP authentication
 # For further information, consult the official icingaweb2 documentation at
@@ -143,3 +163,21 @@ icinga2_web_ldap_groupconf: []
 #    object_filter: 'host_name=*.customer.example.com"'
 
 icinga2_web_permissions: []
+
+# Director Resources configuration
+# For further information, consult the official icingaweb2 documentation at
+# https://icinga.com/docs/director/latest/doc/03-Automation/
+
+#icinga2_web_director:
+#  - name: 'director_db'
+#    db: 'mysql'
+#    host: 'db.example.com'
+#    port: '3306'
+#    dbname: 'director'
+#    username: 'director@example.com'
+#    password: '3xample'
+#    charset: 'utf-8'
+#    use_ssl: '1'
+#    ssl_ca: '/etc/pki/tls/certs/ca-bundle.crt'
+
+icinga2_web_director: []

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -71,6 +71,36 @@
     setype: icingaweb2_config_t
     selevel: s0
 
+- name: configure icingaweb2 director module
+  template:
+    src: templates/etc/icingaweb2/modules/director/config.ini.j2
+    dest: /etc/icingaweb2/modules/director/config.ini
+    owner: root
+    group: icingaweb2
+    mode: 0660
+    seuser: system_u
+    serole: object_r
+    setype: icingaweb2_config_t
+    selevel: s0
+  when: icinga2_web_director | length != 0
+
+- name: configure icingaweb2 director module api
+  template:
+    src: templates/etc/icingaweb2/modules/director/kickstart.ini.j2
+    dest: /etc/icingaweb2/modules/director/kickstart.ini
+    owner: root
+    group: icingaweb2
+    mode: 0660
+    seuser: system_u
+    serole: object_r
+    setype: icingaweb2_config_t
+    selevel: s0
+  when: icinga2_web_director | length != 0
+
+- name: configure icingaweb2 director database
+  command: icingacli director migration run
+  when: icinga2_web_director | length != 0
+
 - name: create icingaweb2 admin password hash
   command: openssl passwd -1 '{{ icinga2_web_admin_pass }}'
   register: icinga2_web_register_admin_hash

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -76,16 +76,53 @@
 
 - name: install modules from github
   git: # noqa 401
-    repo: 'https://github.com/icinga/icingaweb2-module-{{ item }}.git'
-    dest: '/etc/icingaweb2/modules/{{ item }}'
-    update: no
+    repo: 'https://github.com/icinga/icingaweb2-module-{{ item.name }}.git'
+    dest: '/etc/icingaweb2/modules/{{ item.name }}'
+    version: '{{ item.version }}'
   loop: '{{ icinga2_web_modules }}'
   notify: icinga2_web reload icinga2
 
 - name: enable modules from github
   file:
-    src: '/etc/icingaweb2/modules/{{ item }}'
-    dest: '/etc/icingaweb2/enabledModules/{{ item }}'
+    src: '/etc/icingaweb2/modules/{{ item.name }}'
+    dest: '/etc/icingaweb2/enabledModules/{{ item.name }}'
     state: link
   loop: '{{ icinga2_web_modules }}'
   notify: icinga2_web reload icinga2
+
+- name: create icingaweb2 director user for background daemon
+  user:
+    name: icingadirector
+    group: icingaweb2
+    shell: '/bin/false'
+    home: '/var/lib/icingadirector'
+    system: yes
+  when: icinga2_web_director | length != 0
+
+- name: create home directory for icingaweb2 director daemon user
+  file:
+    name: /var/lib/icingadirector
+    state: directory
+    owner: icingadirector
+    group: icingaweb2
+    mode: 0750
+    seuser: system_u
+    serole: object_r
+    setype: var_lib_t
+    selevel: s0
+  when: icinga2_web_director | length != 0
+
+- name: install systemd service for icingaweb2 director daemon
+  copy:
+    src: /etc/icingaweb2/modules/director/contrib/systemd/icinga-director.service
+    remote_src: yes
+    dest: /etc/systemd/system
+  when: icinga2_web_director | length != 0
+
+- name: enable and start systemd service for icingaweb2 director daemon
+  systemd:
+    name: icinga-director.service
+    state: started
+    daemon_reload: yes
+    enabled: yes
+  when: icinga2_web_director | length != 0

--- a/templates/etc/icingaweb2/modules/director/config.ini.j2
+++ b/templates/etc/icingaweb2/modules/director/config.ini.j2
@@ -1,0 +1,7 @@
+;{{ ansible_managed }}
+; Configuration from Icingaweb2 version 2.6.2-1
+
+{% for resourceconf in icinga2_web_director %}
+[db]
+resource = "{{ resourceconf.name }}"
+{% endfor %}

--- a/templates/etc/icingaweb2/modules/director/kickstart.ini.j2
+++ b/templates/etc/icingaweb2/modules/director/kickstart.ini.j2
@@ -1,0 +1,9 @@
+;{{ ansible_managed }}
+; Configuration from Icingaweb2 version 2.6.2-1
+
+[config]
+endpoint = "{{ icinga2_web_director_api_host }}"
+host = "{{ icinga2_web_director_api_host }}"
+port = "{{ icinga2_web_director_api_port }}"
+username = "{{ icinga2_web_director_api_user }}"
+password = "{{ icinga2_web_director_api_pass }}"

--- a/templates/etc/icingaweb2/resources.ini.j2
+++ b/templates/etc/icingaweb2/resources.ini.j2
@@ -36,3 +36,17 @@ bind_dn = "{{ resourceconf.bind_dn }}"
 bind_pw = "{{ resourceconf.bind_pw }}"
 timeout = "{{ resourceconf.timeout }}"
 {% endfor %}
+
+{% for resourceconf in icinga2_web_director %}
+[{{ resourceconf.name }}]
+type = "db"
+db = "{{ resourceconf.db }}"
+host = "{{ resourceconf.host }}"
+port = "{{ resourceconf.port }}"
+dbname = "{{ resourceconf.dbname }}"
+username = "{{ resourceconf.username }}"
+password = "{{ resourceconf.password }}"
+charset = "{{ resourceconf.charset }}"
+use_ssl = "{{ resourceconf.use_ssl }}"
+ssl_ca = "{{ resourceconf.ssl_ca }}"
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY

Add the abillity to install icinga director if corresponding vars have been set.

! The `icinga2_web_modules` var had to be changed to provide the module's version and name instead of only a name.
```
- icinga2_web_modules: []
-  #- graphite

+ icinga2_web_modules: []
+  #- name: graphite
+  #  version: master
```


##### ISSUE TYPE
 - Feature Pull Request

##### ADDITIONAL INFORMATION
In order to run the system.d service on a CentOS7 server an additional php package (`rh-php71-php-process.x86_64`) is required. I'm not quite sure if/where this dependency should be specified.
