### PR TITLE
Remove unnecessary newline in roles.ini template

### DIFF
--- a/templates/etc/icingaweb2/roles.ini.j2
+++ b/templates/etc/icingaweb2/roles.ini.j2
@@ -14,7 +14,6 @@ users = "{{ item.users | join(',') }}"
 {% if item.groups is defined %}
 groups = "{{ item.groups | join(',') }}"
 {% endif %}
-
 permissions = "{{ item.permissions | join(',') }}"
 {% if item.object_filter is defined %}
 monitoring/filter/objects = "{{ item.object_filter }}"


### PR DESCRIPTION
##### SUMMARY
Remove unnecessary newline in roles.ini template

Currently the playbook adds this space:
```
 [service-accounts]                                                                                                                                                                                                
 users = "incident-bot"                                                                                                                                                     
+
 permissions = "module/monitoring" 
```
