### PR TITLE
Adds debian support and fixes selinux

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -72,6 +72,14 @@
     owner: root
     group: icingaweb2
     mode: 0755
+
+- name: ensure icingaweb2 modules directory is present and set selinux
+  file:
+    name: /etc/icingaweb2/enabledModules
+    state: directory
+    owner: root
+    group: icingaweb2
+    mode: 0755
     seuser: system_u
     serole: object_r
     setype: icingaweb2_config_t

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -42,7 +42,7 @@
     login_password: '{{ icinga2_web_database_root_pass }}'
     ssl_ca: '{{ icinga2_web_ca_path }}'
     state: import
-    target: /usr/share/doc/icingaweb2/schema/mysql.schema.sql
+    target: icinga2_web_mysql_schema_sql_path
   run_once: True
   when:
     - not ansible_check_mode

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -42,7 +42,7 @@
     login_password: '{{ icinga2_web_database_root_pass }}'
     ssl_ca: '{{ icinga2_web_ca_path }}'
     state: import
-    target: icinga2_web_mysql_schema_sql_path
+    target: '{{ icinga2_web_mysql_schema_sql_path }}'
   run_once: True
   when:
     - not ansible_check_mode

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,14 @@
 ---
 
+# package list needed for icingaweb2
+icinga2_web_packages:
+  - icingaweb2
+  - icingacli
+  - python3-pymysql
+  - python3-selinux
+  - python3-semanage
+  - mariadb-client
+  - git
+
 # path to ca store
 icinga2_web_ca_path: "/etc/ssl/certs/ca-certificates.crt"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,8 @@
 ---
 
+# mysql.schema.sql path for debian
+icinga2_web_mysql_schema_sql_path: /usr/share/icingaweb2/etc/schema/mysql.schema.sql
+
 # package list needed for icingaweb2
 icinga2_web_packages:
   - icingaweb2

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-# mysql.schema.sql path for debian
+# mysql.schema.sql path for distributions based on redhat
 icinga2_web_mysql_schema_sql_path: /usr/share/doc/icingaweb2/schema/mysql.schema.sql
 
 # package list needed for icingaweb2

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,8 @@
 ---
 
+# mysql.schema.sql path for debian
+icinga2_web_mysql_schema_sql_path: /usr/share/doc/icingaweb2/schema/mysql.schema.sql
+
 # package list needed for icingaweb2
 icinga2_web_packages:
   - icingaweb2


### PR DESCRIPTION
##### SUMMARY
This PR adds debian support and fixes some known ansible selinux bug, where if the directory not already exists, the context cannot be set.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.11.1]
```
