### PR TITLE
fix: change when condition so it wont crash ansible

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -254,7 +254,7 @@
     ('admin', 1, '{{ icinga2_web_register_admin_hash.stdout }}')"
   when:
     - not ansible_check_mode
-    - icinga2_web_register_admin_hash
+    - not icinga2_web_register_admin_hash.skipped
     - icinga2_web_register_icingaweb2_imported.rc == 1
 
 - name: Configure grafana


### PR DESCRIPTION
##### SUMMARY
The ansible crashed during standard roll out:

```
TASK [adfinis.icinga2_web : Insert icingaweb2 admin password into database] **************************************************************************************************************************************************
[ERROR]: Task failed: Conditional result (True) was derived from value of type 'dict' at 'adfinis.icinga2_web/tasks/configuration.yml:261:7'. Conditionals must have a boolean result.

Task failed.
Origin: adfinis.icinga2_web/tasks/configuration.yml:249:3

247     msg: "{{ icinga2_web_register_admin_hash }}"
248
249 - name: Insert icingaweb2 admin password into database # noqa no-changed-when
      ^ column 3

<<< caused by >>>

Conditional result (True) was derived from value of type 'dict' at 'adfinis.icinga2_web/tasks/configuration.yml:261:7'. Conditionals must have a boolean result.
Origin: adfinis.icinga2_web/tasks/configuration.yml:261:7

259   when:
260     - not ansible_check_mode
261     - icinga2_web_register_admin_hash
          ^ column 7

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [....]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result (True) was derived from value of type 'dict' at 'adfinis-roles/adfinis.icinga2_web/tasks/configuration.yml:261:7'. Conditionals must have a boolean result."}
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### ANSIBLE VERSION
```
ansible [core 2.19.4]
  python version = 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] (/opt/ansible/bin/python3)
  jinja version = 3.1.6
 pyyaml version = 6.0.3 (with libyaml v0.2.5)
```

```
