### PR TITLE
feat!: remove fail2ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This role has the following dependencies:
 ``` yaml
 roles:
 - name: 'adfinis.icinga2_agent'
-- name: 'robertdebock.fail2ban'
 
 collections:
   - ansible.posix

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,6 @@
 
 dependencies:
   - name: adfinis.icinga2_agent
-  - name: robertdebock.fail2ban
 
 galaxy_info:
   role_name: icinga2_web

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -10,10 +10,6 @@
     state: present
   when: icinga2_web_use_icingadb
 
-- name: Install fail2ban using role
-  ansible.builtin.include_role:
-    name: robertdebock.fail2ban
-
 # Allow httpd to connect to the mysql database
 - name: Set httpd_can_network_connect_db flag on and keep it persistent across reboots
   ansible.posix.seboolean:


### PR DESCRIPTION
This breaking PR removes fail2ban, as it should be installed separately as part of a playbook instead of a role dependency.